### PR TITLE
Disable POSIX mode.

### DIFF
--- a/quick-cd.sh
+++ b/quick-cd.sh
@@ -10,6 +10,9 @@
 # (at your option) any later version.
 #
 
+# Disable POSIX-mode to relax constraints for func names.
+set +o posix
+
 #
 # Select a dir to go from a hot list using `dialog`
 # It uses a `hotlist` file from Midnight Commander by default

--- a/quick-cd.sh
+++ b/quick-cd.sh
@@ -10,16 +10,13 @@
 # (at your option) any later version.
 #
 
-# Disable POSIX-mode to relax constraints for func names.
-set +o posix
-
 #
 # Select a dir to go from a hot list using `dialog`
 # It uses a `hotlist` file from Midnight Commander by default
 #
 # TODO Add functions to edit (add/remove) hot list entries
 #
-function quick-cd()
+function quick_cd()
 {
     local -r hl=${SMART_PROMPT_HOTLIST:-~/.config/mc/hotlist}
     test -r ${hl} || { echo "* No hotlist file exists yet or read permission is not granted *" > /dev/stderr && exit 1; }

--- a/smart-prompt.inputrc
+++ b/smart-prompt.inputrc
@@ -57,7 +57,7 @@ $if Bash
 "\e[1;5B": "\C-e \C-a\C-k cd -\n\C-y\b"
 
 # Show hot dirs list (Alt+RightArrow) (from MidnightCommander) and `pushd` into choosed one
-"\e[1;3C": "\C-e \C-a\C-k quick-cd\n\C-y\b"
+"\e[1;3C": "\C-e \C-a\C-k quick_cd\n\C-y\b"
 
 # popd on Alt+LeftArrow
 "\e[1;3D": "\C-e \C-u popd\n\C-y\b"


### PR DESCRIPTION
Function names with `-` character are prohibited in bash POSIX-mode and some programs enforce it.